### PR TITLE
Add Shapes classes

### DIFF
--- a/src/StandardUI.Base/Media/ArcSegment.cs
+++ b/src/StandardUI.Base/Media/ArcSegment.cs
@@ -1,0 +1,15 @@
+﻿namespace Microsoft.StandardUI.Media
+{
+    public class ArcSegment : PathSegment
+    {
+        public Point Point { get; init; }
+
+        public Size Size { get; init; }
+
+        public float RotationAngle { get; init; } = 0;
+
+        public bool IsLargeArc { get; init; } = false;
+
+        public SweepDirection SweepDirection { get; init; } = SweepDirection.Counterclockwise;
+    }
+}

--- a/src/StandardUI.Base/Media/BezierSegment.cs
+++ b/src/StandardUI.Base/Media/BezierSegment.cs
@@ -1,0 +1,11 @@
+﻿namespace Microsoft.StandardUI.Media
+{
+    public class BezierSegment : PathSegment
+    {
+        public Point Point1 { get; init; }
+
+        public Point Point2 { get; init; }
+
+        public Point Point3 { get; init; }
+    }
+}

--- a/src/StandardUI.Base/Media/Brush.cs
+++ b/src/StandardUI.Base/Media/Brush.cs
@@ -1,0 +1,6 @@
+﻿namespace Microsoft.StandardUI.Media
+{
+    public class Brush
+    {
+    }
+}

--- a/src/StandardUI.Base/Media/BrushMappingMode.cs
+++ b/src/StandardUI.Base/Media/BrushMappingMode.cs
@@ -1,0 +1,8 @@
+namespace Microsoft.StandardUI.Media
+{
+    public enum BrushMappingMode
+    {
+        Absolute = 0,
+        RelativeToBoundingBox = 1
+    }
+}

--- a/src/StandardUI.Base/Media/FillRule.cs
+++ b/src/StandardUI.Base/Media/FillRule.cs
@@ -1,0 +1,8 @@
+namespace Microsoft.StandardUI.Media
+{
+    public enum FillRule
+    {
+        EvenOdd = 0,
+        Nonzero = 1
+    }   
+}

--- a/src/StandardUI.Base/Media/Geometry.cs
+++ b/src/StandardUI.Base/Media/Geometry.cs
@@ -1,0 +1,9 @@
+﻿namespace Microsoft.StandardUI.Media
+{
+    public class Geometry
+    {
+        public float StandardFlatteningTolerance { get; init; } = 0.25f;
+
+        public Transform? Transform { get; init; } = null;
+    }
+}

--- a/src/StandardUI.Base/Media/GradientBrush.cs
+++ b/src/StandardUI.Base/Media/GradientBrush.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Microsoft.StandardUI.Media
+{
+    public class GradientBrush : Brush
+    {
+        /// <summary>
+        /// A collection of the GradientStop objects associated with the brush, each of which specifies a color and an offset along the brush's gradient axis.
+        /// The default is an empty collection.
+        /// </summary>
+        public IReadOnlyList<GradientStop> GradientStops { get; init; } = Array.Empty<GradientStop>();
+
+        /// <summary>
+        /// A BrushMappingMode value that specifies how to interpret the gradient brush's positioning coordinates. The default is RelativeToBoundingBox.
+        /// </summary>
+        public BrushMappingMode MappingMode { get; init; } = BrushMappingMode.RelativeToBoundingBox;
+
+        /// <summary>
+        /// The type of spread method used to paint the gradient. The default is Pad.
+        /// </summary>
+        public GradientSpreadMethod SpreadMethod { get; init; } = GradientSpreadMethod.Pad;
+    }
+}

--- a/src/StandardUI.Base/Media/GradientSpreadMethod.cs
+++ b/src/StandardUI.Base/Media/GradientSpreadMethod.cs
@@ -1,0 +1,9 @@
+namespace Microsoft.StandardUI.Media
+{
+    public enum GradientSpreadMethod
+    {
+        Pad = 0,
+        Reflect = 1,
+        Repeat = 2
+    }
+}

--- a/src/StandardUI.Base/Media/GradientStop.cs
+++ b/src/StandardUI.Base/Media/GradientStop.cs
@@ -1,0 +1,12 @@
+﻿using System.Drawing;
+
+namespace Microsoft.StandardUI.Media
+{
+    public class GradientStop
+    {
+        // The default is Transparent
+        public Color Color { get; init; }
+
+        public float Offset { get; init; } = 0;
+    }
+}

--- a/src/StandardUI.Base/Media/LineSegment.cs
+++ b/src/StandardUI.Base/Media/LineSegment.cs
@@ -1,0 +1,7 @@
+﻿namespace Microsoft.StandardUI.Media
+{
+    public class LineSegment : PathSegment
+    {
+        public Point Point { get; init; }
+    }
+}

--- a/src/StandardUI.Base/Media/LinearGradientBrush.cs
+++ b/src/StandardUI.Base/Media/LinearGradientBrush.cs
@@ -1,0 +1,9 @@
+﻿namespace Microsoft.StandardUI.Media
+{
+    public class LinearGradientBrush : GradientBrush
+    {
+        public Point StartPoint { get; init; }
+
+        public Point EndPoint { get; init; }
+    }
+}

--- a/src/StandardUI.Base/Media/PathFigure.cs
+++ b/src/StandardUI.Base/Media/PathFigure.cs
@@ -7,7 +7,6 @@ namespace Microsoft.StandardUI.Media
     {
         public IReadOnlyList<PathSegment> Segments { get; init; } = Array.Empty<PathSegment>();
 
-        // TODO: Supply default point
         public Point StartPoint { get; init; }
 
         public bool IsClosed { get; init; } = false;

--- a/src/StandardUI.Base/Media/PathFigure.cs
+++ b/src/StandardUI.Base/Media/PathFigure.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Microsoft.StandardUI.Media
+{
+    public class PathFigure
+    {
+        public IReadOnlyList<PathSegment> Segments { get; init; } = Array.Empty<PathSegment>();
+
+        // TODO: Supply default point
+        public Point StartPoint { get; init; }
+
+        public bool IsClosed { get; init; } = false;
+
+        public bool IsFilled { get; init; } = true;
+    }
+}

--- a/src/StandardUI.Base/Media/PathGeometry.cs
+++ b/src/StandardUI.Base/Media/PathGeometry.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Microsoft.StandardUI.Media
+{
+    public class PathGeometry : Geometry
+    {
+        public IReadOnlyList<PathFigure> Figures { get; init; } = Array.Empty<PathFigure>();
+
+        public FillRule FillRule { get; init; } = FillRule.EvenOdd;
+    }
+}

--- a/src/StandardUI.Base/Media/PathSegment.cs
+++ b/src/StandardUI.Base/Media/PathSegment.cs
@@ -1,0 +1,6 @@
+﻿namespace Microsoft.StandardUI.Media
+{
+    public class PathSegment
+    {
+    }
+}

--- a/src/StandardUI.Base/Media/PenLineCap.cs
+++ b/src/StandardUI.Base/Media/PenLineCap.cs
@@ -1,0 +1,23 @@
+namespace Microsoft.StandardUI.Media
+{
+    /// <summary>
+    /// Describes the shape at the end of a line or segment.
+    /// </summary>
+    public enum PenLineCap
+    {
+        /// <summary>
+        /// A cap that does not extend past the last point of the line. Comparable to no line cap.
+        /// </summary>
+        Flat = 0,
+
+        /// <summary>
+        /// A rectangle that has a height equal to the line thickness and a length equal to half the line thickness.
+        /// </summary>
+        Square = 1,
+
+        /// <summary>
+        /// A semicircle that has a diameter equal to the line thickness.
+        /// </summary>
+        Round = 2
+    }
+}

--- a/src/StandardUI.Base/Media/PenLineJoin.cs
+++ b/src/StandardUI.Base/Media/PenLineJoin.cs
@@ -1,0 +1,23 @@
+namespace Microsoft.StandardUI.Media
+{
+    /// <summary>
+    /// Describes the shape that joins two lines or segments.
+    /// </summary>
+    public enum PenLineJoin
+    {
+        /// <summary>
+        /// Line joins use regular angular vertices.
+        /// </summary>
+        Miter = 0,
+
+        /// <summary>
+        /// Line joins use beveled vertices.
+        /// </summary>
+        Bevel = 1,
+
+        /// <summary>
+        /// Line joins use rounded vertices.
+        /// </summary>
+        Round = 2
+    }
+}

--- a/src/StandardUI.Base/Media/PolyBezierSegment.cs
+++ b/src/StandardUI.Base/Media/PolyBezierSegment.cs
@@ -1,0 +1,7 @@
+﻿namespace Microsoft.StandardUI.Media
+{
+    public class PolyBezierSegment : PathSegment
+    {
+        public Points Points { get; init; }
+    }
+}

--- a/src/StandardUI.Base/Media/PolyBezierSegment.cs
+++ b/src/StandardUI.Base/Media/PolyBezierSegment.cs
@@ -1,7 +1,10 @@
-﻿namespace Microsoft.StandardUI.Media
+﻿using System;
+using System.Collections.Generic;
+
+namespace Microsoft.StandardUI.Media
 {
     public class PolyBezierSegment : PathSegment
     {
-        public Points Points { get; init; }
+        public IReadOnlyList<Point> Points { get; init; } = Array.Empty<Point>();
     }
 }

--- a/src/StandardUI.Base/Media/PolyLineSegment.cs
+++ b/src/StandardUI.Base/Media/PolyLineSegment.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Microsoft.StandardUI.Media
+{
+    public class PolyLineSegment : PathSegment
+    {
+        public IReadOnlyList<Point> Points { get; init; } = Array.Empty<Point>();
+    }
+}

--- a/src/StandardUI.Base/Media/PolyQuadraticBezierSegment.cs
+++ b/src/StandardUI.Base/Media/PolyQuadraticBezierSegment.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Microsoft.StandardUI.Media
+{
+    public class PolyQuadraticBezierSegment : PathSegment
+    {
+        public IReadOnlyList<Point> Points { get; init; } = Array.Empty<Point>();
+    }
+}

--- a/src/StandardUI.Base/Media/QuadraticBezierSegment.cs
+++ b/src/StandardUI.Base/Media/QuadraticBezierSegment.cs
@@ -1,0 +1,9 @@
+﻿namespace Microsoft.StandardUI.Media
+{
+    public class QuadraticBezierSegment : PathSegment
+    {
+        public Point Point1 { get; init; }
+
+        public Point Point2 { get; init; }
+    }
+}

--- a/src/StandardUI.Base/Media/RadialGradientBrush.cs
+++ b/src/StandardUI.Base/Media/RadialGradientBrush.cs
@@ -1,0 +1,11 @@
+﻿namespace Microsoft.StandardUI.Media
+{
+    public class RadialGradientBrush : GradientBrush
+    {
+        public Point Center { get; init; } = Point.CenterDefault;
+
+        public Point GradientOrigin { get; init; } = Point.CenterDefault;
+
+        public float RadiusX { get; init; } = 0.5f;
+    }
+}

--- a/src/StandardUI.Base/Media/RotateTransform.cs
+++ b/src/StandardUI.Base/Media/RotateTransform.cs
@@ -1,0 +1,12 @@
+﻿namespace Microsoft.StandardUI.Media
+{
+
+    public class RotateTransform : Transform
+    {
+        public float Angle { get; init; } = 0;
+
+        public float CenterX { get; init; } = 0;
+
+        public float CenterY { get; init; } = 0;
+    }
+}

--- a/src/StandardUI.Base/Media/ScaleTransform.cs
+++ b/src/StandardUI.Base/Media/ScaleTransform.cs
@@ -1,0 +1,13 @@
+﻿namespace Microsoft.StandardUI.Media
+{
+    public class ScaleTransform : Transform
+    {
+        public float CenterX { get; init; } = 0;
+
+        public float CenterY { get; init; } = 0;
+
+        public float ScaleX { get; init; } = 1.0f;
+
+        public float ScaleY { get; init; } = 1.0f;
+    }
+}

--- a/src/StandardUI.Base/Media/SolidColorBrush.cs
+++ b/src/StandardUI.Base/Media/SolidColorBrush.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.StandardUI.Drawing;
+
+namespace Microsoft.StandardUI.Media
+{
+    public class SolidColorBrush : Brush
+    {
+        public Color Color { get; init; }
+    }
+}

--- a/src/StandardUI.Base/Media/SweepDirection.cs
+++ b/src/StandardUI.Base/Media/SweepDirection.cs
@@ -1,0 +1,8 @@
+namespace Microsoft.StandardUI.Media
+{
+    public enum SweepDirection
+    {
+        Counterclockwise = 0,
+        Clockwise = 1
+    }   
+}

--- a/src/StandardUI.Base/Media/Transform.cs
+++ b/src/StandardUI.Base/Media/Transform.cs
@@ -1,0 +1,6 @@
+﻿namespace Microsoft.StandardUI.Media
+{
+    public class Transform
+    {
+    }
+}

--- a/src/StandardUI.Base/Media/TransformGroup.cs
+++ b/src/StandardUI.Base/Media/TransformGroup.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Microsoft.StandardUI.Media
+{
+    public class TransformGroup : Transform
+    {
+        public IReadOnlyList<Transform> Children { get; init; } = Array.Empty<Transform>();
+    }
+}

--- a/src/StandardUI.Base/Media/TranslateTransform.cs
+++ b/src/StandardUI.Base/Media/TranslateTransform.cs
@@ -1,0 +1,9 @@
+﻿namespace Microsoft.StandardUI.Media
+{
+    public class TranslateTransform : Transform
+    {
+        public float X { get; init; } = 0;
+
+        public float Y { get; init; } = 0;
+    }
+}

--- a/src/StandardUI.Base/Point.cs
+++ b/src/StandardUI.Base/Point.cs
@@ -6,6 +6,8 @@ namespace Microsoft.StandardUI
     [DebuggerDisplay("{X}, {Y}")]
     public struct Point : IEquatable<Point>
     {
+        public static readonly Point CenterDefault = new Point(0.5f, 0.5f);
+
         public Point(float x, float y)
         {
             X = x;

--- a/src/StandardUI.Base/Shapes/Ellipse.cs
+++ b/src/StandardUI.Base/Shapes/Ellipse.cs
@@ -1,0 +1,6 @@
+﻿namespace Microsoft.StandardUI.Shapes
+{
+    public class Ellipse : Shape
+    {
+    }
+}

--- a/src/StandardUI.Base/Shapes/Line.cs
+++ b/src/StandardUI.Base/Shapes/Line.cs
@@ -1,0 +1,13 @@
+﻿namespace Microsoft.StandardUI.Shapes
+{
+    public class Line : Shape
+    {
+        public float X1 { get; init; } = 0;
+
+        public float Y1 { get; init; } = 0;
+
+        public float X2 { get; init; } = 0;
+
+        public float Y2 { get; init; } = 0;
+    }
+}

--- a/src/StandardUI.Base/Shapes/Path.cs
+++ b/src/StandardUI.Base/Shapes/Path.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.StandardUI.Media;
+
+namespace Microsoft.StandardUI.Shapes
+{
+    public class Path : Shape
+    {
+        public Geometry? Data { get; init; } = null;
+    }
+}

--- a/src/StandardUI.Base/Shapes/Polygon.cs
+++ b/src/StandardUI.Base/Shapes/Polygon.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.StandardUI.Media;
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.StandardUI.Shapes
+{
+    public class Polygon : Shape
+    {
+        public FillRule FillRule { get; init; } = FillRule.EvenOdd;
+
+        public IReadOnlyList<Point> Points { get; init; } = Array.Empty<Point>();
+    }
+}

--- a/src/StandardUI.Base/Shapes/Polyline.cs
+++ b/src/StandardUI.Base/Shapes/Polyline.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.StandardUI.Media;
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.StandardUI.Shapes
+{
+    public class Polyline : Shape
+    {
+        public FillRule FillRule { get; init; } = FillRule.EvenOdd;
+
+        public IReadOnlyList<Point> Points { get; init; } = Array.Empty<Point>();
+    }
+}

--- a/src/StandardUI.Base/Shapes/Rectangle.cs
+++ b/src/StandardUI.Base/Shapes/Rectangle.cs
@@ -1,0 +1,15 @@
+﻿namespace Microsoft.StandardUI.Shapes
+{
+    public class Rectangle : Shape
+    {
+        /// <summary>
+        /// Gets or sets the x-axis radius of the ellipse that is used to round the corners of the rectangle.
+        /// </summary>
+        public float RadiusX { get; init; } = 0;
+
+        /// <summary>
+        /// Gets or sets the y-axis radius of the ellipse that is used to round the corners of the rectangle.
+        /// </summary>
+        public float RadiusY { get; init; } = 0;
+    }
+}

--- a/src/StandardUI.Base/Shapes/Shape.cs
+++ b/src/StandardUI.Base/Shapes/Shape.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.StandardUI.Media;
+
+namespace Microsoft.StandardUI.Shapes
+{
+    // TODO: Add superclass
+    public class Shape // : IUIElement
+    {
+        /// <summary>
+        /// A Brush that paints/fills the shape interior. The default is null (a null brush) which is evaluated as Transparent for rendering.
+        /// </summary>
+        public Brush? Fill { get; init; } = null;
+
+        /// <summary>
+        /// A Brush that specifies how the Shape outline is painted. The default is null.
+        /// </summary>
+        public Brush? Stroke { get; init; } = null;
+
+        /// <summary>
+        /// The width of the Shape outline, in pixels. The default value is 0.
+        /// </summary>
+        public float StrokeThickness { get; init; } = 0;
+
+        /// <summary>
+        /// The limit on the ratio of the miter length to the StrokeThickness of a Shape element. This value is always a positive number that is greater than or equal to 1.
+        /// </summary>
+        public float StrokeMiterLimit { get; init; } = 10;
+
+        /// <summary>
+        /// A value of the PenLineCap enumeration that specifies the shape at the start of a Stroke. The default is Flat.
+        /// </summary>
+        public PenLineCap StrokeLineCap { get; init; } = PenLineCap.Flat;
+
+        /// <summary>
+        /// A value of the PenLineJoin enumeration that specifies the join appearance. The default value is Miter.
+        /// </summary>
+        public PenLineJoin StrokeLineJoin { get; init; } = PenLineJoin.Miter;
+    }
+}


### PR DESCRIPTION
Add the shapes and supporting types, moving them
to use updated conventions like float instead of double,
concrete classes instead of interfaces, and init properties
instead of settings.

A subsequent PR will integrate these types fully.