### PR TITLE
State management for Cocoa example

### DIFF
--- a/examples/Interop.Cocoa/Interop.Cocoa.csproj
+++ b/examples/Interop.Cocoa/Interop.Cocoa.csproj
@@ -97,6 +97,8 @@
     <Compile Include="ViewController.designer.cs">
       <DependentUpon>ViewController.cs</DependentUpon>
     </Compile>
+    <Compile Include="IsExternalInit.cs" />
+    <Compile Include="OptionsPane.cs" />
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Main.storyboard" />

--- a/examples/Interop.Cocoa/IsExternalInit.cs
+++ b/examples/Interop.Cocoa/IsExternalInit.cs
@@ -1,0 +1,4 @@
+﻿namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit { }
+}

--- a/examples/Interop.Cocoa/OptionsPane.cs
+++ b/examples/Interop.Cocoa/OptionsPane.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Diagnostics;
+using AppKit;
+using Foundation;
+using Microsoft.StandardUI;
+using Microsoft.StandardUI.Elements;
+using Microsoft.StandardUI.State;
+using Native = Microsoft.StandardUI.Cocoa.Native;
+
+namespace Interop.Cocoa
+{
+    // Use record to avoid writing constructor boilerplate.
+    // Use State<T> to enable internal modification (records can't be modified in place).
+    public record OptionsData(
+        string[] Configurations,
+        State<int> SelectedConfiguration,
+        string[] Platforms,
+        State<int> SelectedPlatform,
+        State<bool> GenerateOverflowChecks,
+        State<bool> EnableOptimizations,
+        State<bool> GenerateXmlDoc,
+        State<string> XmlDocPath,
+        State<string> Symbols,
+        string[] PlatformTargets,
+        State<int> SelectedPlatformTarget);
+
+    public record OptionsPane(OptionsData Data, Action Ok, Action Cancel) : RControl
+    {
+        // README: Close/reopen solution after building the first time. Workaround until VSMac has source generator support.
+        // Testing layout here. A real implementation would have to bind to/update a real view model.
+        public override Element Build(Context context) =>
+            new Column(
+                new Row(
+                    VerticalAlignment.Center,
+                    TextBlock("Configuration:"),
+                    Combobox(Data.Configurations, Data.SelectedConfiguration),
+                    TextBlock("Platform:"),
+                    Combobox(Data.Platforms, Data.SelectedPlatform)
+                    ),
+                TextBlock("General Options"),
+                new Column(
+                    Checkbox("Generate overflow checks", Data.GenerateOverflowChecks),
+                    Checkbox("Enable optimizations", Data.EnableOptimizations),
+
+                    // By Binding to GenerateXmlDoc we can update Enabled if the checkbox is checked.
+                    Data.GenerateXmlDoc.Bind(() =>
+                        new Row(
+                            VerticalAlignment.Center,
+                            Checkbox("Generate xml documentation:", Data.GenerateXmlDoc),
+                            TextEdit(Data.XmlDocPath)
+                                .Enabled(Data.GenerateXmlDoc)
+                                .Width(float.PositiveInfinity)
+                                .Expand(),
+                            new Native.NSButton()
+                                .Title("Browse...")
+                                .Enabled(Data.GenerateXmlDoc)
+                                .BezelStyle(NSBezelStyle.Rounded)
+                            )
+                        ),
+                    new Row(
+                        VerticalAlignment.Center,
+                        TextBlock("Define Symbols:"),
+                        TextEdit(Data.Symbols)
+                            .Width(float.PositiveInfinity)
+                        ),
+                    new Row(
+                        VerticalAlignment.Center,
+                        TextBlock("Platform targets:"),
+                        Combobox(Data.PlatformTargets, Data.SelectedPlatformTarget)
+                        ).Margin(10),
+                    new Row(
+                        new Native.NSButton()
+                            .Title("Cancel")
+                            .BezelStyle(NSBezelStyle.Rounded)
+                            .Activated(Cancel),
+                        new Native.NSButton()
+                            .Title("Ok")
+                            .BezelStyle(NSBezelStyle.Rounded)
+                            .KeyEquivalent("\r")
+                            .Activated(Ok)
+                        ).Right()
+                )
+            );
+
+        
+
+        static Native.NSTextField TextBlock(string text) =>
+            new Native.NSTextField()
+                .StringValue(text)
+                .BackgroundColor(NSColor.Clear)
+                .Bezeled(false)
+                .Editable(false);
+
+        static Native.NSPopUpButton Combobox(string[] options, State<int> selectedIndex) =>
+            new Native.NSPopUpButton()
+                .Items(options)
+                .IndexOfSelectedItem(selectedIndex)
+                .Activated((sender, args) => selectedIndex.Value = (int)((NSPopUpButton)sender).IndexOfSelectedItem);
+
+        // We assume we're the only one modifing the underlying state. If that isn't the case,
+        // value.Bind(() => ...) can be used to respond to outside influence.
+        static Native.NSButton Checkbox(string title, State<bool> value) =>
+            new Native.NSButton()
+                .Title(title)
+                .State(value ? NSCellStateValue.On : NSCellStateValue.Off)
+                .Activated(() => value.Value = !value.Value)
+                .ButtonType(NSButtonType.Switch);
+
+        static Native.NSTextField TextEdit(State<string> value) =>
+            new Native.NSTextField()
+                .StringValue(value)
+                .Changed((sender, args) =>
+                value.Value = ((NSTextField)((NSNotification)sender).Object).StringValue);
+    }
+}

--- a/examples/Interop.Cocoa/ViewController.cs
+++ b/examples/Interop.Cocoa/ViewController.cs
@@ -20,74 +20,24 @@ namespace Interop.Cocoa
         {
             base.ViewDidLoad();
 
-            // README: Close/reopen solution after building the first time. Workaround until VSMac has source generator support.
-            // Testing layout here. A real implementation would have to bind to/update a real view model.
-            host.RootElement = () =>
-                State.Inject<int>((state, setState) =>
-                    new Column(
-                        new Row(
-                            VerticalAlignment.Center,
-                            TextBlock("Configuration:"),
-                            new Native.NSPopUpButton()
-                                .Items("Debug (Active)", "Release")
-                                .Activated(PrintConfiguration),
-                            TextBlock("Platform:"),
-                            new Native.NSPopUpButton()
-                                .Items("Any CPU")
-                            ),
-                        TextBlock("General Options"),
-                        new Column(
-                            new Native.NSButton()
-                                .Title($"Generate overflow checks {state}")
-                                .State(state % 2 == 0 ? NSCellStateValue.Off : NSCellStateValue.On)
-                                .ButtonType(NSButtonType.Switch)
-                                .Activated(() => setState(state + 1)),
-                            new Native.NSButton()
-                                .Title("Enable optimizations")
-                                .State(NSCellStateValue.Off)
-                                .ButtonType(NSButtonType.Switch),
-                            new Row(
-                                VerticalAlignment.Center,
-                                new Native.NSButton()
-                                    .Title("Generate xml documentation:")
-                                    .State(NSCellStateValue.Off)
-                                    .ButtonType(NSButtonType.Switch),
-                                new Native.NSTextField()
-                                    .StringValue("Interop.Cocoa.xml")
-                                    .Changed(() => Debug.WriteLine("xml doc changed"))
-                                    .Width(float.PositiveInfinity)
-                                    .Expand(),
-                                new Native.NSButton()
-                                    .Title("Browse...")
-                                    .BezelStyle(NSBezelStyle.Rounded)
-                                ),
-                            new Row(
-                                TextBlock("Define Symbols:"),
-                                new Native.NSTextField()
-                                    .StringValue("__MACOS__;__UNDEFINED__;DEBUG;")
-                                    .Width(float.PositiveInfinity)
-                                 ),
-                            new Row(
-                                TextBlock("Platform targets:"),
-                                new Native.NSPopUpButton()
-                                    .Items("Any CPU", "x86", "x64", "Itanium")
-                                )
-                            ).Margin(10)
-                        )
-                    );
-        }
-
-        static Native.NSTextField TextBlock(string text) =>
-            new Native.NSTextField()
-                .StringValue(text)
-                .BackgroundColor(NSColor.Clear)
-                .Bezeled(false)
-                .Editable(false);
-
-        private void PrintConfiguration(object sender, EventArgs e)
-        {
-            var btn = (NSPopUpButton)sender;
-            Debug.WriteLine($"Configuration: {btn.Title}");
+            // Generate some initial data. This would normally be read from configuration.
+            OptionsData data = new(
+                Configurations: new[] { "Debug (Active)", "Release" },
+                SelectedConfiguration: new(0),
+                Platforms: new[] { "Any CPU" },
+                SelectedPlatform: new(0),
+                GenerateOverflowChecks: new(false),
+                EnableOptimizations: new(false),
+                GenerateXmlDoc: new(false),
+                XmlDocPath: new("Interop.Cocoa.xml"),
+                Symbols: new("__MACOS__;__UNDEFINED__;DEBUG;"),
+                PlatformTargets: new[] { "Any CPU", "x86", "x64", "Itanium" },
+                SelectedPlatformTarget: new(0)
+                );
+            host.RootElement = () => new OptionsPane(
+                data,
+                Ok: () => Debug.WriteLine($"Ok {data}"),
+                Cancel: () => Debug.WriteLine($"Cancel {data}"));
         }
 
         public override NSObject RepresentedObject

--- a/src/StandardUI.Base/Elements/RControl.cs
+++ b/src/StandardUI.Base/Elements/RControl.cs
@@ -1,0 +1,29 @@
+﻿namespace Microsoft.StandardUI.Elements
+{
+    /// <summary>
+    /// Enables record based Controls
+    /// </summary>
+    /// <remarks>
+    /// Record types can not inherit from class types. Since Element is a class, we can not have
+    /// record Elements. RControl is a record that is implicitly convertable to Element. This lets
+    /// you use records to write your UI.
+    /// </remarks>
+    public abstract record RControl
+    {
+        public static implicit operator Element(RControl control) =>
+            new RControlAdapter(control);
+
+        public abstract Element Build(Context context);
+    }
+
+    class RControlAdapter : Control
+    {
+        RControl inner;
+
+        public RControlAdapter(RControl inner) =>
+            this.inner = inner;
+
+        public override Element Build(Context context) =>
+            inner.Build(context);
+    }
+}

--- a/src/StandardUI.Base/State/State.cs
+++ b/src/StandardUI.Base/State/State.cs
@@ -12,10 +12,10 @@ namespace Microsoft.StandardUI.State
         public static InjectState<State<T>> Inject<T>(Func<T> newState, Func<T, Action<T>, Element> callback) =>
             new InjectState<State<T>>(() => new State<T>(newState()),
                 state => callback(state.Value, newState => state.Value = newState));
-        public static InjectState<State<T>> UnsafeInject<T>(Func<State<T>, Element> callback) where T : new() =>
-            new UnsafeInjectState<State<T>>(() => new(), callback);
-        public static InjectState<State<T>> UnsafeInject<T>(Func<T> newState, Func<State<T>, Element> callback) =>
-            new UnsafeInjectState<State<T>>(() => new State<T>(newState()), callback);
+        public static UnsafeInjectState<T> UnsafeInject<T>(Func<T, Element> callback) where T : new() =>
+            new UnsafeInjectState<T>(() => new(), callback);
+        public static UnsafeInjectState<T> UnsafeInject<T>(Func<T> newState, Func<T, Element> callback) =>
+            new UnsafeInjectState<T>(() => new State<T>(newState()), callback);
     }
 
     public sealed class State<T> : INotifyPropertyChanged, IDisposable
@@ -30,6 +30,13 @@ namespace Microsoft.StandardUI.State
         public State() => this.v = Activator.CreateInstance<T>();
 
         public State(T v) => this.v = v;
+
+        // An implicit conversion operator would be useful. Unforunately it allows the following:
+        // State<bool> foo = false;
+        // foo = true;
+        //
+        // This ends up creating two states, but 99% of the time you really want
+        // foo.Value = true;
 
         public T Value
         {

--- a/src/StandardUI.Base/State/State.cs
+++ b/src/StandardUI.Base/State/State.cs
@@ -9,13 +9,13 @@ namespace Microsoft.StandardUI.State
     {
         public static InjectState<State<T>> Inject<T>(Func<T, Action<T>, Element> callback) where T : new() =>
             new InjectState<State<T>>(() => new(), state => callback(state.Value, newState => state.Value = newState));
-        public static InjectState<State<T>> Inject<T>(Func<T> newState, Func<T, Action<T>, Element> callback) =>
-            new InjectState<State<T>>(() => new State<T>(newState()),
+        public static InjectState<State<T>> Inject<T>(Func<T> newValue, Func<T, Action<T>, Element> callback) =>
+            new InjectState<State<T>>(() => new State<T>(newValue()),
                 state => callback(state.Value, newState => state.Value = newState));
-        public static UnsafeInjectState<T> UnsafeInject<T>(Func<T, Element> callback) where T : new() =>
-            new UnsafeInjectState<T>(() => new(), callback);
-        public static UnsafeInjectState<T> UnsafeInject<T>(Func<T> newState, Func<T, Element> callback) =>
-            new UnsafeInjectState<T>(() => new State<T>(newState()), callback);
+        public static UnsafeInjectState<State<T>> UnsafeInject<T>(Func<State<T>, Element> callback) where T : new() =>
+            new UnsafeInjectState<State<T>>(() => new(), callback);
+        public static UnsafeInjectState<State<T>> UnsafeInject<T>(Func<T> newValue, Func<State<T>, Element> callback) =>
+            new UnsafeInjectState<State<T>>(() => new State<T>(newValue()), callback);
     }
 
     public sealed class State<T> : INotifyPropertyChanged, IDisposable

--- a/src/StandardUI.Cocoa/Native/NSPopUpButtonBase.cs
+++ b/src/StandardUI.Cocoa/Native/NSPopUpButtonBase.cs
@@ -6,6 +6,12 @@ namespace Microsoft.StandardUI.Cocoa.Native
 {
     public abstract partial class NSPopUpButtonBase<TSubclass, TView>
     {
+        public static CustomUIProperty<AppKit.NSPopUpButton, int> IndexOfSelectedItemProperty =
+            new(0, (view, value) => view.SelectItem(value));
+
+        public TSubclass IndexOfSelectedItem(int index) =>
+            Set(IndexOfSelectedItemProperty, index);
+
         static ConditionalWeakTable<Internal.ViewState, string[]> previousItems = new();
         protected readonly string[] items;
 


### PR DESCRIPTION
InjectState - UnsafeInjectState no longer needs to implement INotifyPropertyChanged
RControl - Create controls using record