### PR TITLE
Fix Cocoa baseline alginment

### DIFF
--- a/examples/Interop.Cocoa/AppDelegate.cs
+++ b/examples/Interop.Cocoa/AppDelegate.cs
@@ -1,5 +1,6 @@
 ﻿using AppKit;
 using Foundation;
+using Microsoft.StandardUI.Cocoa;
 
 namespace Interop.Cocoa
 {
@@ -8,6 +9,12 @@ namespace Interop.Cocoa
     {
         public AppDelegate()
         {
+            // By updating the GlobalContext you can change fonts/colors/ect for all content
+            // inside NSStandardUIHost.
+            NSStandardUIHost.SetGlobalContext(new()
+            {
+                { typeof(Style), new Style(HeaderFont: NSFont.BoldSystemFontOfSize(13)) }
+            });
         }
 
         public override void DidFinishLaunching(NSNotification notification)

--- a/examples/Interop.Cocoa/Interop.Cocoa.csproj
+++ b/examples/Interop.Cocoa/Interop.Cocoa.csproj
@@ -99,6 +99,7 @@
     </Compile>
     <Compile Include="IsExternalInit.cs" />
     <Compile Include="OptionsPane.cs" />
+    <Compile Include="Style.cs" />
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Main.storyboard" />

--- a/examples/Interop.Cocoa/OptionsPane.cs
+++ b/examples/Interop.Cocoa/OptionsPane.cs
@@ -28,16 +28,19 @@ namespace Interop.Cocoa
     {
         // README: Close/reopen solution after building the first time. Workaround until VSMac has source generator support.
         // Testing layout here. A real implementation would have to bind to/update a real view model.
-        public override Element Build(Context context) =>
-            new Column(
+        public override Element Build(Context context)
+        {
+            var style = context.Get<Style>();
+            return new Column(
                 new Row(
-                    VerticalAlignment.Center,
+                    VerticalAlignment.Baseline,
                     TextBlock("Configuration:"),
                     Combobox(Data.Configurations, Data.SelectedConfiguration),
                     TextBlock("Platform:"),
                     Combobox(Data.Platforms, Data.SelectedPlatform)
-                    ),
-                TextBlock("General Options"),
+                    ).Margin(0, 10, 0, 10),
+                TextBlock("General Options")
+                    .Font(style.HeaderFont),
                 new Column(
                     Checkbox("Generate overflow checks", Data.GenerateOverflowChecks),
                     Checkbox("Enable optimizations", Data.EnableOptimizations),
@@ -45,7 +48,7 @@ namespace Interop.Cocoa
                     // By Binding to GenerateXmlDoc we can update Enabled if the checkbox is checked.
                     Data.GenerateXmlDoc.Bind(() =>
                         new Row(
-                            VerticalAlignment.Center,
+                            VerticalAlignment.Baseline,
                             Checkbox("Generate xml documentation:", Data.GenerateXmlDoc),
                             TextEdit(Data.XmlDocPath)
                                 .Enabled(Data.GenerateXmlDoc)
@@ -58,16 +61,17 @@ namespace Interop.Cocoa
                             )
                         ),
                     new Row(
-                        VerticalAlignment.Center,
+                        VerticalAlignment.Baseline,
                         TextBlock("Define Symbols:"),
                         TextEdit(Data.Symbols)
                             .Width(float.PositiveInfinity)
+                            .Margin(0, 0, 6, 6)
                         ),
                     new Row(
-                        VerticalAlignment.Center,
+                        VerticalAlignment.Baseline,
                         TextBlock("Platform targets:"),
                         Combobox(Data.PlatformTargets, Data.SelectedPlatformTarget)
-                        ).Margin(10),
+                        ),
                     new Row(
                         new Native.NSButton()
                             .Title("Cancel")
@@ -79,10 +83,9 @@ namespace Interop.Cocoa
                             .KeyEquivalent("\r")
                             .Activated(Ok)
                         ).Right()
-                )
+                ).Margin(15, 10)
             );
-
-        
+        }
 
         static Native.NSTextField TextBlock(string text) =>
             new Native.NSTextField()

--- a/examples/Interop.Cocoa/Style.cs
+++ b/examples/Interop.Cocoa/Style.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using AppKit;
+
+namespace Interop.Cocoa
+{
+    /// <summary>
+    /// Define fonts/colors used throughout the application here.
+    /// </summary>
+    public record Style(NSFont HeaderFont);
+}

--- a/src/StandardUI.Base/Elements/Margin.cs
+++ b/src/StandardUI.Base/Elements/Margin.cs
@@ -36,12 +36,12 @@ namespace Microsoft.StandardUI.Elements
         public static Margin Margin(this Element e, float left, float top) =>
             new Margin(e, new(left, top));
         public static Margin Margin(this Element e, float left, float top, float right, float bottom) =>
-            new Margin(e, new(left, right, top, bottom));
+            new Margin(e, new(left, top, right, bottom));
         public static Margin Margin(this Element e, Thickness margin) =>
             new Margin(e, margin);
     }
 
-    internal class MarginNode : NodeBase<Margin>
+    class MarginNode : NodeBase<Margin>
     {
         Node child;
 

--- a/src/StandardUI.Cocoa/Native/NSViewBase.cs
+++ b/src/StandardUI.Cocoa/Native/NSViewBase.cs
@@ -176,7 +176,7 @@ namespace Microsoft.StandardUI.Cocoa.Native
             return size;
         }
 
-        CGSize ComputeSize(TView view, Size availableSize)
+        (CGSize, float?) ComputeSize(TView view, Size availableSize)
         {
             double width;
             double height;
@@ -191,16 +191,18 @@ namespace Microsoft.StandardUI.Cocoa.Native
             else
                 width = size.Width;
 
+            float? baseline = null;
             if (float.IsNaN(size.Height))
             {
                 intrinsicSize ??= IntrinsicSize(view);
                 height = intrinsicSize.Value.Height;
+                baseline = (float)(height - (view.AlignmentRectInsets.Bottom + view.BaselineOffsetFromBottom));
             }
             else if (float.IsInfinity(size.Height))
                 height = availableSize.Height;
             else
                 height = size.Height;
-            return new(width, height);
+            return (new(width, height), baseline);
         }
     }
 


### PR DESCRIPTION
Baseline is now set correctly for Cocoa controls. Example updated to take advantage of baseline alignment.

Margin - Fix parameter order in .Margin
NSStandardUIHost - Add global settings
OptionsPane - Use baseline alignment. Tweak margins.