### PR TITLE
Rename Row/Column/Stack

### DIFF
--- a/examples/HelloWorld/HelloWorld.cs
+++ b/examples/HelloWorld/HelloWorld.cs
@@ -4,7 +4,7 @@ using Microsoft.StandardUI.State;
 using static Microsoft.StandardUI.Elements.Factories;
 
 App.Run(() =>
-    State.Inject<int>((count, setCount) => Row(
+    State.Inject<int>((count, setCount) => HStack(
         VerticalAlignment.Center,
         Text("Hello World 🐱‍🐉")
             .Margin(2),

--- a/examples/Interop.Cocoa/OptionsPane.cs
+++ b/examples/Interop.Cocoa/OptionsPane.cs
@@ -31,8 +31,8 @@ namespace Interop.Cocoa
         public override Element Build(Context context)
         {
             var style = context.Get<Style>();
-            return new Column(
-                new Row(
+            return new VStack(
+                new HStack(
                     VerticalAlignment.Baseline,
                     TextBlock("Configuration:"),
                     Combobox(Data.Configurations, Data.SelectedConfiguration),
@@ -41,13 +41,13 @@ namespace Interop.Cocoa
                     ).Margin(0, 10, 0, 10),
                 TextBlock("General Options")
                     .Font(style.HeaderFont),
-                new Column(
+                new VStack(
                     Checkbox("Generate overflow checks", Data.GenerateOverflowChecks),
                     Checkbox("Enable optimizations", Data.EnableOptimizations),
 
                     // By Binding to GenerateXmlDoc we can update Enabled if the checkbox is checked.
                     Data.GenerateXmlDoc.Bind(() =>
-                        new Row(
+                        new HStack(
                             VerticalAlignment.Baseline,
                             Checkbox("Generate xml documentation:", Data.GenerateXmlDoc),
                             TextEdit(Data.XmlDocPath)
@@ -60,19 +60,19 @@ namespace Interop.Cocoa
                                 .BezelStyle(NSBezelStyle.Rounded)
                             )
                         ),
-                    new Row(
+                    new HStack(
                         VerticalAlignment.Baseline,
                         TextBlock("Define Symbols:"),
                         TextEdit(Data.Symbols)
                             .Width(float.PositiveInfinity)
                             .Margin(0, 0, 6, 6)
                         ),
-                    new Row(
+                    new HStack(
                         VerticalAlignment.Baseline,
                         TextBlock("Platform targets:"),
                         Combobox(Data.PlatformTargets, Data.SelectedPlatformTarget)
                         ),
-                    new Row(
+                    new HStack(
                         new Native.NSButton()
                             .Title("Cancel")
                             .BezelStyle(NSBezelStyle.Rounded)

--- a/examples/Interop.Wpf/DinoControl.cs
+++ b/examples/Interop.Wpf/DinoControl.cs
@@ -16,7 +16,7 @@ namespace Interop.Wpf
         public string Incomming { get; }
 
         public override Element Build(Context context, int state, Action<int> setState) =>
-            Column(
+            VStack(
                 TextBlock().Text(Incomming),
                 MyUserControlWrapper().MyValue(state),
                 Button()
@@ -24,7 +24,7 @@ namespace Interop.Wpf
                     .OnClick(args => setState(state + 1))
                     .Margin(2)
                     .Center(),
-                Row(VerticalAlignment.Baseline,
+                HStack(VerticalAlignment.Baseline,
                     Text("HELLO", fontSize: 32),
                     Button("world", () => { }),
                     Text(" trailing text")),

--- a/examples/StateManagement/StateManagement.cs
+++ b/examples/StateManagement/StateManagement.cs
@@ -27,7 +27,7 @@ WpfComboBox WpfComboBox() => new();
 /// </summary>
 Element StateExample() =>
     State.Inject<int>((state, setState) =>
-        Row(
+        HStack(
             WpfButton()
                 .Content($"Hello world {state}")
                 .OnClick(_ => setState(state + 1))
@@ -52,7 +52,7 @@ Element StateExample() =>
 /// </summary>
 Element UnsafeStateExample() =>
     State.UnsafeInject<int>(state =>
-        Row(
+        HStack(
             WpfButton()
                 .Content(state.Bind(() => $"Hello world {state}"))
                 .OnClick(_ => state.Value += 1)
@@ -78,7 +78,7 @@ Element UnsafeStateExample() =>
 /// </summary>
 Element ExplicitStateExample() =>
     ExplicitState.Inject<int>(state =>
-        Row(
+        HStack(
             WpfButton()
                 .Content(state.Bind(value => $"Hello world {value}"))
                 .OnClick(_ => state.Set(c => c + 1))
@@ -111,7 +111,7 @@ Element ExplicitStateExample() =>
 /// </summary>
 Element ImplicitStateExample() =>
     ImplicitState.Inject<int>(state =>
-        Row(
+        HStack(
             WpfButton()
                 .Content("TODO")
                 .OnClick(_ => state.Value += 1)
@@ -132,7 +132,7 @@ App.Run(() => {
     };
     var exampleNames = examples.Select(ex => ex.Item1).ToList();
 
-    return State.Inject<int>((state, setState) => Column(
+    return State.Inject<int>((state, setState) => VStack(
             HorizontalAlignment.Center,
             WpfComboBox()
                 .ItemsSource(exampleNames)

--- a/src/StandardUI.Base/Elements/Button.cs
+++ b/src/StandardUI.Base/Elements/Button.cs
@@ -52,13 +52,13 @@ namespace Microsoft.StandardUI.Elements
                 },
                 gotFocus: visualizeFocus => setState(state with { VisualizeFocus = visualizeFocus }),
                 lostFocus: () => setState(state with { VisualizeFocus = false, SpaceDown = false }),
-                child: Stack(
+                child: ZStack(
                         Rectangle(
                             new Paint(
                                 fill: state.Highlight ? 0xFFBEE6FD : 0xFFDDDDDD,
                                 stroke: state.Highlight ? 0xFF3C7FB1 : 0xFF707070)
                             ).Expand(),
-                        Stack(
+                        ZStack(
                             Content,
                             Rectangle(
                                 new Paint(

--- a/src/StandardUI.Base/Elements/Expand.cs
+++ b/src/StandardUI.Base/Elements/Expand.cs
@@ -4,10 +4,10 @@ using System.Collections.Generic;
 namespace Microsoft.StandardUI.Elements
 {
     /// <summary>
-    /// Take up remaining space in a <see cref="Row"/>, <see cref="Column"/>, or <see cref="Stack"/>.
+    /// Take up remaining space in a <see cref="HStack"/>, <see cref="VStack"/>, or <see cref="ZStack"/>.
     /// </summary>
-    /// <remarks><see cref="Row"/> and <see cref="Column"/> split their remaing space based on the <see cref="Factor"/>.
-    /// For <see cref="Stack"/> any non-zero factor fills the entire stack.</remarks>
+    /// <remarks><see cref="HStack"/> and <see cref="VStack"/> split their remaing space based on the <see cref="Factor"/>.
+    /// For <see cref="ZStack"/> any non-zero factor fills the entire stack.</remarks>
     /// <param name="factor">The amount of space to take up relative to other expanded elements. 0 indicates the element should not be expanded.</param>
     public class Expand
     {

--- a/src/StandardUI.Base/Elements/Factories.cs
+++ b/src/StandardUI.Base/Elements/Factories.cs
@@ -12,11 +12,11 @@ namespace Microsoft.StandardUI.Elements
             Text(text, foreground, fontSize, typeface);
         public static Button Button(Element content, Action click) =>
             new(content, click);
-        public static Row Row(VerticalAlignment alignment, params Expand[] children) => new(alignment, children);
-        public static Row Row(params Expand[] children) => new(children);
-        public static Column Column(HorizontalAlignment alignment, params Expand[] children) => new(alignment, children);
-        public static Column Column(params Expand[] children) => new(children);
-        public static Stack Stack(params Expand[] children) => new(children);
+        public static HStack HStack(VerticalAlignment alignment, params Expand[] children) => new(alignment, children);
+        public static HStack HStack(params Expand[] children) => new(children);
+        public static VStack VStack(HorizontalAlignment alignment, params Expand[] children) => new(alignment, children);
+        public static VStack VStack(params Expand[] children) => new(children);
+        public static ZStack ZStack(params Expand[] children) => new(children);
         public static Input Input(
             ControlType controlType,
             Element child,

--- a/src/StandardUI.Base/Elements/HStack.cs
+++ b/src/StandardUI.Base/Elements/HStack.cs
@@ -5,18 +5,18 @@ using System.Linq;
 
 namespace Microsoft.StandardUI.Elements
 {
-    public class Row : Container<Expand>
+    public class HStack : Container<Expand>
     {
-        public Row(VerticalAlignment alignment, FlowDirection? flowDirection, params Expand[] children) : base(children)
+        public HStack(VerticalAlignment alignment, FlowDirection? flowDirection, params Expand[] children) : base(children)
         {
             Alignment = alignment;
             FlowDirection = flowDirection;
         }
-        public Row(VerticalAlignment alignment, params Expand[] children) : this(alignment, null, children) { }
+        public HStack(VerticalAlignment alignment, params Expand[] children) : this(alignment, null, children) { }
 
-        public Row(FlowDirection? flowDirection, params Expand[] children) : this(VerticalAlignment.Top, flowDirection, children) { }
+        public HStack(FlowDirection? flowDirection, params Expand[] children) : this(VerticalAlignment.Top, flowDirection, children) { }
 
-        public Row(params Expand[] children) : this(VerticalAlignment.Top, children)
+        public HStack(params Expand[] children) : this(VerticalAlignment.Top, children)
         { }
 
         public VerticalAlignment Alignment { get; }
@@ -36,10 +36,10 @@ namespace Microsoft.StandardUI.Elements
 
         public override bool IsLayoutInvalid(Container<Expand> oldContainer)
         {
-            var oldRow = (Row)oldContainer;
-            if (Alignment != oldRow.Alignment)
+            var oldHStack = (HStack)oldContainer;
+            if (Alignment != oldHStack.Alignment)
                 return true;
-            return Children.Zip(oldRow.Children, (a, b) => (a, b)).Any(pair => pair.a.Factor != pair.b.Factor);
+            return Children.Zip(oldHStack.Children, (a, b) => (a, b)).Any(pair => pair.a.Factor != pair.b.Factor);
         }
 
         public override Element ToElement(Expand child) => child.Child;

--- a/src/StandardUI.Base/Elements/VStack.cs
+++ b/src/StandardUI.Base/Elements/VStack.cs
@@ -5,11 +5,11 @@ using System.Linq;
 
 namespace Microsoft.StandardUI.Elements
 {
-    public class Column : Container<Expand>
+    public class VStack : Container<Expand>
     {
-        public Column(HorizontalAlignment alignment, params Expand[] children) : base(children) =>
+        public VStack(HorizontalAlignment alignment, params Expand[] children) : base(children) =>
             Alignment = alignment;
-        public Column(params Expand[] children) : this(HorizontalAlignment.Left, children) { }
+        public VStack(params Expand[] children) : this(HorizontalAlignment.Left, children) { }
 
         public HorizontalAlignment Alignment { get; }
 
@@ -23,10 +23,10 @@ namespace Microsoft.StandardUI.Elements
 
         public override bool IsLayoutInvalid(Container<Expand> oldContainer)
         {
-            var oldColumn = (Column)oldContainer;
-            if (oldColumn.Alignment != Alignment)
+            var oldVStack = (VStack)oldContainer;
+            if (oldVStack.Alignment != Alignment)
                 return true;
-            return Children.Zip(oldColumn.Children, (a, b) => (a, b)).Any(pair => pair.a.Factor != pair.b.Factor);
+            return Children.Zip(oldVStack.Children, (a, b) => (a, b)).Any(pair => pair.a.Factor != pair.b.Factor);
         }
 
         public override Element ToElement(Expand child) => child.Child;

--- a/src/StandardUI.Base/Elements/ZStack.cs
+++ b/src/StandardUI.Base/Elements/ZStack.cs
@@ -7,9 +7,9 @@ using System.Linq;
 
 namespace Microsoft.StandardUI.Elements
 {
-    public class Stack : Container<Expand>
+    public class ZStack : Container<Expand>
     {
-        public Stack(params Expand[] children) : base(children) { }
+        public ZStack(params Expand[] children) : base(children) { }
 
         public override (Size, float?) Arrange(Context context, Size availableSize, List<Node> children) =>
             throw new NotImplementedException();
@@ -19,14 +19,14 @@ namespace Microsoft.StandardUI.Elements
         public override Element ToElement(Expand child) => child.Child;
 
         public override Node CreateNode(Node? parent, Context context) =>
-            new StackNode(parent, context, this);
+            new ZStackNode(parent, context, this);
     }
 
-    internal class StackNode : NodeBase<Stack>
+    internal class ZStackNode : NodeBase<ZStack>
     {
         private List<PseudoLayer> children;
 
-        public StackNode(Node? parent, Context context, Stack stack) : base(parent, context, stack)
+        public ZStackNode(Node? parent, Context context, ZStack stack) : base(parent, context, stack)
         {
             var children = stack.Children;
             this.children = new List<PseudoLayer>(children.Count);
@@ -99,7 +99,7 @@ namespace Microsoft.StandardUI.Elements
                 child.OnRender(context);
         }
 
-        protected override void UpdateElement(Stack oldStack, Context oldContext)
+        protected override void UpdateElement(ZStack oldStack, Context oldContext)
         {
             var newCount = Element.Children.Count;
             if (children.Count < newCount)

--- a/tests/StandardUI.Base.Tests/BaselineTests.cs
+++ b/tests/StandardUI.Base.Tests/BaselineTests.cs
@@ -19,9 +19,9 @@ namespace Microsoft.StandardUI.Base.Tests
         }
 
         [Fact]
-        public void RowBaseline()
+        public void HStackBaseline()
         {
-            var element = Row(VerticalAlignment.Baseline,
+            var element = HStack(VerticalAlignment.Baseline,
                 new SetBaseline(Rectangle(Colors.Red, 10, 100), 0),
                 Rectangle(Colors.Blue, 10, 100));
             var node = element.CreateNode(null, context);
@@ -33,7 +33,7 @@ namespace Microsoft.StandardUI.Base.Tests
         [Fact]
         public void RowBaseline_SkipTop()
         {
-            var element = Row(VerticalAlignment.Baseline,
+            var element = HStack(VerticalAlignment.Baseline,
                 new SetBaseline(Rectangle(Colors.Red, 10, 100), 0).Top(),
                 Rectangle(Colors.Blue, 10, 100));
             var node = element.CreateNode(null, context);
@@ -45,7 +45,7 @@ namespace Microsoft.StandardUI.Base.Tests
         [Fact]
         public void ColumnBaseline()
         {
-            var element = Column(
+            var element = VStack(
                 Rectangle(Colors.Red, 10, 10),
                 new SetBaseline(Rectangle(Colors.Green, 10, 10), 5),
                 Rectangle(Colors.Blue, 10, 10));


### PR DESCRIPTION
Rename, per chat with Max:

`Row` -> `HStack`
`Column` -> `VStack`
`Stack` -> `ZStack`

`Stack` is more familiar term to XAML devs, who associate row & column with Grids.
Also the new names match SwiftUI.
Flutter uses `Row` / `Column`, but for our target user base, familiar with XAML conventions, `HStack` and `VStack` seem better.