### PR TITLE
Restore generic StandardControlImplementation

### DIFF
--- a/samples/Microcharts/Charts/BarChart.cs
+++ b/samples/Microcharts/Charts/BarChart.cs
@@ -20,12 +20,12 @@ namespace Microcharts
     ///
     /// A bar chart.
     /// </summary>
-    public class BarChartImplementation : PointChartImplementation
+    public class BarChartImplementation<T> : PointChartImplementation<T> where T : IBarChart
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="T:Microcharts.BarChart"/> class.
         /// </summary>
-        public BarChartImplementation(IBarChart control) : base(control)
+        public BarChartImplementation(T control) : base(control)
         {
             PointSize = 0;
         }

--- a/samples/Microcharts/Charts/Chart.cs
+++ b/samples/Microcharts/Charts/Chart.cs
@@ -31,7 +31,7 @@ namespace Microcharts
     /// <summary>
     /// A chart.
     /// </summary>
-    public abstract class ChartImplementation : StandardControlImplementation, INotifyPropertyChanged
+    public abstract class ChartImplementation<T> : StandardControlImplementation<T>, INotifyPropertyChanged where T : IChart
     {
         private float animationProgress;
         private double margin = 20, labelTextSize = 16;
@@ -42,15 +42,11 @@ namespace Microcharts
         private Task invalidationPlanification;
         private CancellationTokenSource animationCancellation;
 
-        protected IChart Control { get; }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="T:Microcharts.Chart"/> class.
         /// </summary>
-        public ChartImplementation(IChart control) : base((IStandardControlEnvironmentPeer)control)
+        public ChartImplementation(T control) : base(control)
         {
-            Control = control;
-
             PropertyChanged += OnPropertyChanged;
 
             // Animation doesn't currently work, so disable it by default
@@ -423,10 +419,10 @@ namespace Microcharts
         /// <param name="target">The target instance.</param>
         /// <param name="onInvalidate">Callback when chart is invalidated.</param>
         /// <typeparam name="TTarget">The target subsriber type.</typeparam>
-        public InvalidatedWeakEventHandler<TTarget> ObserveInvalidate<TTarget>(TTarget target, Action<TTarget> onInvalidate)
+        public InvalidatedWeakEventHandler<T, TTarget> ObserveInvalidate<TTarget>(TTarget target, Action<TTarget> onInvalidate)
             where TTarget : class
         {
-            var weakHandler = new InvalidatedWeakEventHandler<TTarget>(this, target, onInvalidate);
+            var weakHandler = new InvalidatedWeakEventHandler<T, TTarget>(this, target, onInvalidate);
             weakHandler.Subsribe();
             return weakHandler;
         }

--- a/samples/Microcharts/Charts/PointChart.cs
+++ b/samples/Microcharts/Charts/PointChart.cs
@@ -24,12 +24,12 @@ namespace Microcharts
     ///
     /// Point chart.
     /// </summary>
-    public class PointChartImplementation : ChartImplementation
+    public class PointChartImplementation<T> : ChartImplementation<T> where T : IPointChart
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="T:Microcharts.PointChart"/> class.
         /// </summary>
-        public PointChartImplementation(IPointChart control) : base(control)
+        public PointChartImplementation(T control) : base(control)
         {
             LabelOrientation = Orientation.Horizontal; // Orientation.Default;
             ValueLabelOrientation = Orientation.Default;

--- a/samples/Microcharts/Charts/RadarChart.cs
+++ b/samples/Microcharts/Charts/RadarChart.cs
@@ -21,11 +21,11 @@ namespace Microcharts
     ///
     /// A radar chart.
     /// </summary>
-    public class RadarChartImplementation : ChartImplementation
+    public class RadarChartImplementation<T> : ChartImplementation<T> where T : IRadarChart
     {
         private const float Epsilon = 0.01f;
 
-        public RadarChartImplementation(IRadarChart control) : base(control)
+        public RadarChartImplementation(T control) : base(control)
         {
         }
 

--- a/samples/Microcharts/WeakEventHandlers/InvalidatedWeakEventHandler.cs
+++ b/samples/Microcharts/WeakEventHandlers/InvalidatedWeakEventHandler.cs
@@ -11,11 +11,11 @@ namespace Microcharts
     /// in memory instead of the actual subscriber.
     /// This could be considered as an acceptable solution in most cases.
     /// </summary>
-    public class InvalidatedWeakEventHandler<TTarget> : IDisposable where TTarget : class
+    public class InvalidatedWeakEventHandler<TControlSource, TTarget> : IDisposable where TControlSource : IChart where TTarget : class
     {
         #region Fields
 
-        private readonly WeakReference<ChartImplementation> sourceReference;
+        private readonly WeakReference<ChartImplementation<TControlSource>> sourceReference;
 
         private readonly WeakReference<TTarget> targetReference;
 
@@ -33,9 +33,9 @@ namespace Microcharts
         /// <param name="source">The source.</param>
         /// <param name="target">The target.</param>
         /// <param name="targetMethod">The target method.</param>
-        public InvalidatedWeakEventHandler(ChartImplementation source, TTarget target, Action<TTarget> targetMethod)
+        public InvalidatedWeakEventHandler(ChartImplementation<TControlSource> source, TTarget target, Action<TTarget> targetMethod)
         {
-            this.sourceReference = new WeakReference<ChartImplementation>(source);
+            this.sourceReference = new WeakReference<ChartImplementation<TControlSource>>(source);
             this.targetReference = new WeakReference<TTarget>(target);
             this.targetMethod = targetMethod;
         }
@@ -48,7 +48,7 @@ namespace Microcharts
         /// Gets a value indicating whether this <see cref="T:Microcharts.InvalidateWeakEventHandler`1"/> is alive.
         /// </summary>
         /// <value><c>true</c> if is alive; otherwise, <c>false</c>.</value>
-        public bool IsAlive => this.sourceReference.TryGetTarget(out ChartImplementation s) && this.targetReference.TryGetTarget(out TTarget t);
+        public bool IsAlive => this.sourceReference.TryGetTarget(out ChartImplementation<TControlSource> s) && this.targetReference.TryGetTarget(out TTarget t);
 
         #endregion
 
@@ -59,7 +59,7 @@ namespace Microcharts
         /// </summary>
         public void Subsribe()
         {
-            if (!this.isSubscribed && this.sourceReference.TryGetTarget(out ChartImplementation source))
+            if (!this.isSubscribed && this.sourceReference.TryGetTarget(out ChartImplementation<TControlSource> source))
             {
                 source.Invalidated += this.OnEvent;
                 this.isSubscribed = true;
@@ -73,7 +73,7 @@ namespace Microcharts
         {
             if (this.isSubscribed)
             {
-                if (this.sourceReference.TryGetTarget(out ChartImplementation source))
+                if (this.sourceReference.TryGetTarget(out ChartImplementation<TControlSource> source))
                 {
                     source.Invalidated -= this.OnEvent;
                 }

--- a/samples/SimpleControls/RadialGaugeImplementation.cs
+++ b/samples/SimpleControls/RadialGaugeImplementation.cs
@@ -12,20 +12,16 @@ namespace SimpleControls
         IBrush? Fill { get; set; }
     }
 
-    public class RadialGaugeImplementation : StandardControlImplementation
+    public class RadialGaugeImplementation<T> : StandardControlImplementation<T> where T : IRadialGauge
     {
-        private readonly IRadialGauge control;
-
-        public RadialGaugeImplementation(IRadialGauge control) : base((IStandardControlEnvironmentPeer)control)
-        {
-            this.control = control;
-        }
+        public RadialGaugeImplementation(T control) : base(control)
+        { }
 
         public override IUIElement? Build()
         {
             var blueBrush = SolidColorBrush().Color(Colors.Blue);
 
-            return Rectangle() .Width(50) .Height(50) .Stroke(blueBrush) .Fill(this.control.Fill);
+            return Rectangle() .Width(50) .Height(50) .Stroke(blueBrush) .Fill(Control.Fill);
         }
     }
 }

--- a/samples/WpfSamplesHost/BarChart.cs
+++ b/samples/WpfSamplesHost/BarChart.cs
@@ -15,7 +15,7 @@ namespace SimpleControls.Wpf
 
         public BarChart()
         {
-            InitImplementation(new BarChartImplementation(this));
+            InitImplementation(new BarChartImplementation<IBarChart>(this));
         }
 
         public IEnumerable<ChartEntry> Entries

--- a/samples/WpfSamplesHost/PointChart.cs
+++ b/samples/WpfSamplesHost/PointChart.cs
@@ -15,7 +15,7 @@ namespace SimpleControls.Wpf
 
         public PointChart()
         {
-            InitImplementation(new PointChartImplementation(this));
+            InitImplementation(new PointChartImplementation<IPointChart>(this));
         }
 
         public IEnumerable<ChartEntry> Entries

--- a/src/StandardUI.SourceGenerator/SourceGenerator.cs
+++ b/src/StandardUI.SourceGenerator/SourceGenerator.cs
@@ -68,11 +68,11 @@ using Microsoft.StandardUI.Wpf;
 
 namespace SimpleControls.Wpf
 {{
-    public class {controlTypeName} : StandardControl, {interfaceFullTypeName}
+    public class {controlTypeName} : StandardControl<{interfaceFullTypeName}>, {interfaceFullTypeName}
     {{
         public {controlTypeName}()
         {{
-            InitImplementation(new {interfaceNamespace}.{controlTypeName}Implementation(this));
+            InitImplementation(new {interfaceNamespace}.{controlTypeName}Implementation<{interfaceFullTypeName}>(this));
         }}");
 
             SourceGenerator.GenerateProperties(interfaceSymbol, controlTypeName, sourceCode);

--- a/src/StandardUI.SourceGenerator/SourceGenerator.cs
+++ b/src/StandardUI.SourceGenerator/SourceGenerator.cs
@@ -68,7 +68,7 @@ using Microsoft.StandardUI.Wpf;
 
 namespace SimpleControls.Wpf
 {{
-    public class {controlTypeName} : StandardControl<{interfaceFullTypeName}>, {interfaceFullTypeName}
+    public class {controlTypeName} : StandardControl, {interfaceFullTypeName}
     {{
         public {controlTypeName}()
         {{

--- a/src/StandardUI/Controls/StandardControlImplementation.cs
+++ b/src/StandardUI/Controls/StandardControlImplementation.cs
@@ -95,4 +95,14 @@ namespace Microsoft.StandardUI.Controls
             return finalSize;
         }
     }
+
+    public abstract class StandardControlImplementation<T> : StandardControlImplementation where T : IControl
+    {
+        public T Control { get; }
+
+        public StandardControlImplementation(T control) : base((IStandardControlEnvironmentPeer)control)
+        {
+            Control = control;
+        }
+    }
 }


### PR DESCRIPTION
I accidentally completed the PR that removed the generic StandardControlImplementation which I had really created to get Bret's feedback on. Reverting that change.