### PR TITLE
Bump Roslyn 4.3.0 -> 4.3.1

### DIFF
--- a/src/Microsoft.StandardUI.Analyzers/Microsoft.StandardUI.Analyzers.csproj
+++ b/src/Microsoft.StandardUI.Analyzers/Microsoft.StandardUI.Analyzers.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
   </ItemGroup>
 


### PR DESCRIPTION
This is needed to get the fix mentioned here:
https://github.com/dotnet/roslyn/issues/63780#issuecomment-1281037219

It fixes System.Immutable not found errors for System.Immutable 6.0.0