### PR TITLE
Add control example support

### DIFF
--- a/component-model-ex/src/Microsoft.ComponentModelEx/ContentPropertyAttribute.cs
+++ b/component-model-ex/src/Microsoft.ComponentModelEx/ContentPropertyAttribute.cs
@@ -13,7 +13,7 @@ namespace Microsoft.ComponentModelEx
         /// <summary>
         /// The name of the property that is associated with direct content
         /// </summary>
-        public string Name { get; }
+        public string? Name { get; }
 
         /// <summary>
         /// Creates a new content property attriubte that indicates that associated

--- a/component-model-ex/src/Microsoft.ComponentModelEx/Tooling/UIExample.cs
+++ b/component-model-ex/src/Microsoft.ComponentModelEx/Tooling/UIExample.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Reflection;
+
+namespace Microsoft.ComponentModelEx.Tooling
+{
+    public class UIExample
+    {
+        private string? _description;
+        private MethodInfo _methodInfo;
+
+        public UIExample(string? description, MethodInfo methodInfo)
+        {
+            _description = description;
+            _methodInfo = methodInfo;
+        }
+
+        public UIExample(UIExampleAttribute uiExampleAttribute, MethodInfo methodInfo)
+        {
+            _description = uiExampleAttribute.Description;
+            _methodInfo = methodInfo;
+        }
+
+        public object Create()
+        {
+            if (_methodInfo.GetParameters().Length != 0)
+                throw new InvalidOperationException($"Examples that take parameters aren't yet supported: {GetMethodDisplayName()}");
+
+            return _methodInfo.Invoke(null, null);
+        }
+
+        /// <summary>
+        /// Get a user friendly display name for the example method, suitable for error
+        /// messages.
+        /// </summary>
+        /// <returns>user friendly name of example method</returns>
+        public string GetMethodDisplayName()
+        {
+            return $"{_methodInfo.DeclaringType.Name}.{_methodInfo.Name}";
+        }
+
+        public string? Description => _description;
+
+        public MethodInfo MethodInfo => _methodInfo;
+    }
+}

--- a/component-model-ex/src/Microsoft.ComponentModelEx/Tooling/UIExamples.cs
+++ b/component-model-ex/src/Microsoft.ComponentModelEx/Tooling/UIExamples.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Microsoft.ComponentModelEx.Tooling
+{
+    public class UIExamples
+    {
+        private readonly List<UIExample> _examples = new();
+
+        public void LoadFromAssembly(Assembly assembly)
+        {
+            Type[] types = assembly.GetExportedTypes();
+
+            foreach (Type type in types)
+            {
+                MethodInfo[] methods = type.GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.DeclaredOnly);
+
+                foreach (MethodInfo method in methods)
+                {
+                    UIExampleAttribute? uiExampleAttribute = method.GetCustomAttribute<UIExampleAttribute>(false);
+
+                    if (uiExampleAttribute != null)
+                    {
+                        var uiExample = new UIExample(uiExampleAttribute, method);
+                        _examples.Add(uiExample);
+                    }
+                }
+            }
+        }
+
+        public IEnumerable<UIExample> Examples => _examples;
+    }
+}

--- a/component-model-ex/src/Microsoft.ComponentModelEx/UIExampleAttribute.cs
+++ b/component-model-ex/src/Microsoft.ComponentModelEx/UIExampleAttribute.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace Microsoft.ComponentModelEx
+{
+    /// <summary>
+    /// An attribute that specifies this is an example, for a control or other UI.
+    /// Examples can be shown in a gallery viwer and doc.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class UIExampleAttribute : Attribute
+    {
+        /// <summary>
+        /// Optional description for the example, which can be shown in the viewer.
+        /// </summary>
+        public string? Description { get; }
+
+        /// <summary>
+        /// Creates a new content property attriubte that indicates that associated
+        /// class does not have a content property attribute. This allows a descendent
+        /// to remove an ancestor's declaration of a content property attribute.
+        /// </summary>
+        public UIExampleAttribute()
+        {
+        }
+
+        public UIExampleAttribute(string description)
+        {
+            Description = description;
+        }
+    }
+}

--- a/samples/controls/SimpleControls/ToggleSwitch/ToggleSwitch_Examples.cs
+++ b/samples/controls/SimpleControls/ToggleSwitch/ToggleSwitch_Examples.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.ComponentModelEx;
+using Microsoft.StandardUI;
+using Microsoft.StandardUI.Controls;
+using static SimpleControls.SimpleControlsStatics;
+
+namespace AlohaKit.StandardControls
+{
+    public class ToggleSwitch_Examples
+    {
+        [UIExample("ToggleSwitch")]
+        public static IToggleSwitch SimpleToggleSwitch() =>
+            ToggleSwitch()
+                .Width(40)
+                .Height(30)
+                .BackgroundColor(Colors.Gray)
+                .ThumbColor(Colors.Red);
+
+        [UIExample("ToggleSwitch with green thumb")]
+        public static IToggleSwitch ToggleSwitchWithGreenThumb() =>
+            ToggleSwitch()
+                .Width(40)
+                .Height(30d)
+                .BackgroundColor(Colors.Gray)
+                .ThumbColor(Colors.Green);
+    }
+}

--- a/src/Microsoft.StandardUI.Analyzers/ControlLibraryGenerator.cs
+++ b/src/Microsoft.StandardUI.Analyzers/ControlLibraryGenerator.cs
@@ -72,6 +72,7 @@ namespace Microsoft.StandardUI.SourceGenerator
             var controlLibrary = new ControlLibrary(context, controlLibraryClass, interfaces);
             controlLibrary.GenerateStaticsClass();
             controlLibrary.GenerateFactoryClass();
+            controlLibrary.GenerateExtensionsClasses();
         }
     }
 }


### PR DESCRIPTION
Add support for UIExample, to declare methods as returning
an example control/UI, with all properties set, to be displayed
via control gallery/example viewer tooling.

This PR also enables extension class source generation for
controls.