### PR TITLE
Add support for disabling auto property generation

### DIFF
--- a/src/Microsoft.StandardUI.Analyzers/ControlLibrary.cs
+++ b/src/Microsoft.StandardUI.Analyzers/ControlLibrary.cs
@@ -232,7 +232,7 @@ namespace Microsoft.StandardUI.SourceGenerator
 
         public void GenerateControlClasses(UIFramework uiFramework)
         {
-            foreach (var intface in Interfaces)
+            foreach (Interface intface in Interfaces)
             {
                 intface.Generate(uiFramework);
             }

--- a/src/Microsoft.StandardUI.Analyzers/InterfacePurpose.cs
+++ b/src/Microsoft.StandardUI.Analyzers/InterfacePurpose.cs
@@ -4,6 +4,7 @@
     {
         UIObject,
         StandardUIObject,
+        StandardUIElement,
         StandardControl,
         StandardPanel,
         UISingleton,

--- a/src/Microsoft.StandardUI.Analyzers/KnownTypes.cs
+++ b/src/Microsoft.StandardUI.Analyzers/KnownTypes.cs
@@ -19,7 +19,9 @@
 
         public const string ImportStandardControlAttribute = "Microsoft.StandardUI.ImportStandardControlAttribute";
         public const string ImportControlLibraryAttribute = "Microsoft.StandardUI.ImportControlLibraryAttribute";
-        public const string WpfStandardUIElementAttribute = "Microsoft.StandardUI.WpfStandardUIElementAttribute";
+
+        public const string WpfStandardUIElementAttribute = "Microsoft.StandardUI.Wpf.WpfStandardUIElementAttribute";
+        public const string NoAutoPropertyGenerationAttribute = "Microsoft.StandardUI.NoAutoPropertyGenerationAttribute";
 
         public const string ControlLibraryAttribute = "Microsoft.StandardUI.ControlLibraryAttribute";
 

--- a/src/Microsoft.StandardUI.Wpf/WpfStandardUIElementAttribute.cs
+++ b/src/Microsoft.StandardUI.Wpf/WpfStandardUIElementAttribute.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Microsoft.StandardUI
+namespace Microsoft.StandardUI.Wpf
 {
     [AttributeUsage(AttributeTargets.Class)]
     public class WpfStandardUIElementAttribute : Attribute

--- a/src/Microsoft.StandardUI/NoAutoPropertyGenerationAttribute.cs
+++ b/src/Microsoft.StandardUI/NoAutoPropertyGenerationAttribute.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace Microsoft.StandardUI
+{
+    /// <summary>
+    /// This attribute, when set on a native control class (e.g. a WPF control
+    /// class with [WpfStandardUIElement]) disables disables automatic property
+    /// source generation for the specified property. It can be used when the
+    /// property is provided by the base class, thus no new property need be
+    /// generated. It can also be used when the property registration should
+    /// be customized beyond what the source generator provides, allowing
+    /// the property to be manually registered however is appropriate.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    public sealed class NoAutoPropertyGenerationAttribute : Attribute
+    {
+        /// <summary>
+        /// The name of the property for which autogeneration should be disabled
+        /// </summary>
+        public string Name { get; }
+
+        public NoAutoPropertyGenerationAttribute(string name)
+        {
+            Name = name;
+        }
+    }
+}


### PR DESCRIPTION
This is currently used for native controls that expose an existing property, in their native control base class, rather than needing a new property generated. It can also be used in other cases where the property needs some kind of custom handling beyond what the automatic generator provides.