### PR TITLE
Updated dependencies

### DIFF
--- a/src/Microsoft.StandardUI.Analyzers/Microsoft.StandardUI.Analyzers.csproj
+++ b/src/Microsoft.StandardUI.Analyzers/Microsoft.StandardUI.Analyzers.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Microsoft.StandardUI.CommandLineSourceGenerator/Microsoft.StandardUI.CommandLineSourceGenerator.csproj
+++ b/src/Microsoft.StandardUI.CommandLineSourceGenerator/Microsoft.StandardUI.CommandLineSourceGenerator.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
@@ -8,10 +8,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
-		<PackageReference Include="Microsoft.CodeAnalysis" Version="4.3.1" />
+		<PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
+		<PackageReference Include="Microsoft.CodeAnalysis" Version="4.4.0" />
 		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.3.1" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.4.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/skia/Microsoft.StandardUI.SkiaVisualFramework.Blazor/Microsoft.StandardUI.SkiaVisualFramework.Blazor.csproj
+++ b/src/skia/Microsoft.StandardUI.SkiaVisualFramework.Blazor/Microsoft.StandardUI.SkiaVisualFramework.Blazor.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="2.88.2" />
-    <PackageReference Include="SkiaSharp.Views.Blazor" Version="2.88.2" />
+    <PackageReference Include="SkiaSharp" Version="2.88.3" />
+    <PackageReference Include="SkiaSharp.Views.Blazor" Version="2.88.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/skia/Microsoft.StandardUI.SkiaVisualFramework/Microsoft.StandardUI.SkiaVisualFramework.csproj
+++ b/src/skia/Microsoft.StandardUI.SkiaVisualFramework/Microsoft.StandardUI.SkiaVisualFramework.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="2.88.2" />
+    <PackageReference Include="SkiaSharp" Version="2.88.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bump Roslyn to 17.4, now that VS 17.4 is available on Azure hosted agents.

Also bump Skia Blazor to latest.